### PR TITLE
fix: removed fetch-depth property from checkout of 'npm/cli'

### DIFF
--- a/.github/workflows/benchmark-cli.yml
+++ b/.github/workflows/benchmark-cli.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           repository: ${{ github.event.client_payload.owner }}/${{ github.event.client_payload.repo }}
           ref: ${{ github.event.client_payload.commit_sha }}
-          fetch-depth: 1
           token: ${{ secrets.NPM_DEPLOY_USER_PAT }}
           path: ${{ env.RUNNER_WORKSPACE }}
       # Setup nodejs


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
Fix failing benchmark suite runs.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* Fixes: https://github.com/npm/benchmarks/issues/5
