### PR TITLE
add white background to graph

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -105,6 +105,9 @@ const generateGraph = (name, result) => {
     `  </style>`
   ]
 
+  // add white background
+  svg.push(`  <rect x="${vb.x}" y="${vb.y}" width="${vb.w}" height="${vb.h}" fill="${'#fff'}"></rect>`)
+
   // legend
   managers.forEach((manager, index) => {
     const radius = 4


### PR DESCRIPTION
Hi, I'm the original author of the graph generation code.

When using dark mode in Github the graphs are hard to read:

<img width="662" alt="image" src="https://user-images.githubusercontent.com/15011519/112492625-b44a5500-8d81-11eb-9ba8-9fdba4aeac01.png">

Adding a white background solves this problem.

I've made [the same change](https://github.com/pnpm/benchmarks-of-javascript-package-managers/pull/49) in pnpm's benchmark repo.