### PR TITLE
chore: add private flag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "benchmarks",
   "description": "the npm cli benchmarking suite",
+  "private": true,
   "dependencies": {
     "@octokit/rest": "^18.0.12",
     "npm-package-arg": "^8.1.0",


### PR DESCRIPTION
This will prevent us from accidentally trying to publish this non-package, and will allow us to programmatically differentiate between our package and non-package repos.